### PR TITLE
Fixed a bug that made the display crash when there was no prescriber

### DIFF
--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -244,7 +244,7 @@ class ClaimSearcher extends Component {
         />
       ),
       (c) => <PublishedComponent readOnly={true} pubRef="insuree.InsureePicker" withLabel={false} value={c.insuree} />,
-      (c) => c.prescriber.code+" "+ c.prescriber.lastName+" "+c.prescriber.otherNames ,
+      (c) => `${c.prescriber?.code || ""} ${c.prescriber?.lastName || ""} ${c.prescriber?.otherNames || ""}`,
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateClaimed),
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateProcessed),
       (c) => this.feedbackColFormatter(c),


### PR DESCRIPTION
added ? to the prescriber so the front end doesn't crash when the prescriber is null