### PR TITLE
  fix user that don't have claim_review right cannot create claims

### DIFF
--- a/src/components/ClaimForm.js
+++ b/src/components/ClaimForm.js
@@ -487,8 +487,8 @@ class ClaimForm extends Component {
       isSaved ||
       (!forReview && !forFeedback && claim.status !== 2) ||
       (forReview && (claim.reviewStatus >= 8 || claim.status !== 4)) ||
-      (forFeedback && claim.status !== 4) ||
-      !rights.filter((r) => r === RIGHT_CLAIMREVIEW).length;
+      (forFeedback && claim.status !== 4) //||
+      //!rights.filter((r) => r === RIGHT_CLAIMREVIEW).length;
 
     var actions = [];
     if (!!claim_uuid) {


### PR DESCRIPTION
we've removed the condition of having claim_review right to edit claim form. this was done to allows users that don't have claim_review right like claim administrator and claim contributors to create and modify their claim services