### PR TITLE
Add prescriber validation to claim form

### DIFF
--- a/src/components/ClaimForm.js
+++ b/src/components/ClaimForm.js
@@ -284,6 +284,7 @@ class ClaimForm extends Component {
       return false;
     if(!!this.showPatientCondition && this.showPatientCondition == true && !this.state.claim.patientCondition) return false;
     if (!this.state.claim.insuree) return false;
+    if (!this.state.claim.prescriber) return false;
     if (!this.state.claim.admin) return false;
     if (!this.state.claim.dateClaimed) return false;
     if (!this.state.claim.dateFrom) return false;


### PR DESCRIPTION
The claim form now requires the prescriber field to be present before submission, improving data integrity and ensuring all necessary information is provided.