### PR TITLE
Remove prop from Picker

### DIFF
--- a/src/reports/PrescriberReport.js
+++ b/src/reports/PrescriberReport.js
@@ -69,7 +69,6 @@ const PrescriberReport = (props) => {
                     pubRef="location.HealthFacilityPicker"
                     value={hf}
                     withNull={true}
-                    prescriber={values?.prescriber}
                     onChange={(v) => handleHealthFacilityChange(index, v)}
                   />
                 </Grid>


### PR DESCRIPTION
The prop in the instance of the picker was removed because it was removed from the picker in location