### PR TITLE
OICI : 213 Amelioration transition OP3 -> PEC

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -599,7 +599,7 @@ export function formatClaimGQL(modulesManager, claim, shouldAutogenerate) {
     ${!!claim.patientCondition ? `patientCondition: "${formatGQLString(claim.patientCondition)}"` : ""}
     ${!!claim.referralCode ? `referralCode: "${formatGQLString(claim.referralCode)}"` : ""}
     preAuthorization: ${claim.preAuthorization}
-    isPreAuthorization: ${claim.isPreAuthorization}
+    isPreAuthorization: ${!!claim.isPreAuthorization}
     ${claim.datePreAuthorizationEmergency? `datePreAuthorizationEmergency: "${claim.datePreAuthorizationEmergency}" `: ""}
  `;
 }

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -299,7 +299,7 @@ class ClaimChildPanel extends Component {
   };
 
   render() {
-    const { intl, classes, edited, type, picker, forReview, fetchingPricelist, readOnly = false,preAuth = false } = this.props;
+    const { intl, classes, edited, type, picker, forReview, fetchingPricelist, readOnly = false,preAuth = false , claim} = this.props;
     if (!edited) return null;
     if (!this.props.edited.healthFacility || !this.props.edited.healthFacility[`${this.props.type}sPricelist`]?.id) {
       return (
@@ -352,7 +352,7 @@ class ClaimChildPanel extends Component {
           <PublishedComponent
             readOnly={!!forReview || readOnly}
             pubRef={picker}
-            preAuth={preAuth}
+            preAuth={claim.isPreAuthorization}
             filterOptions={this.props.type==='item' ? filterItemsOptions : filterServicesOptions}
             withLabel={false}
             value={i[type]}
@@ -721,6 +721,7 @@ class ClaimChildPanel extends Component {
 }
 
 const mapStateToProps = (state, props) => ({
+  claim: state.claim.claim,
   fetchingPricelist: !!state.medical_pricelist && state.medical_pricelist.fetchingPricelist,
   servicesPricelists: !!state.medical_pricelist ? state.medical_pricelist.servicesPricelists : {},
   itemsPricelists: !!state.medical_pricelist ? state.medical_pricelist.itemsPricelists : {},

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -352,7 +352,7 @@ class ClaimChildPanel extends Component {
           <PublishedComponent
             readOnly={!!forReview || readOnly}
             pubRef={picker}
-            preAuth={claim.isPreAuthorization}
+            preAuth={!!claim?.isPreAuthorization}
             filterOptions={this.props.type==='item' ? filterItemsOptions : filterServicesOptions}
             withLabel={false}
             value={i[type]}

--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -394,6 +394,23 @@ class Details extends Component {
             }
           />
         </Grid>
+        <Grid item xs={2} className={classes.item}>
+          <TextInput
+            module="claim"
+            label="ClaimFilter.preAuthNo"
+            name="preAuthNo"
+            value={this._filterTextFieldValue("preAuthNo")}
+            onChange={(v) =>
+              this.debouncedOnChangeFilter([
+                {
+                  id: "preAuthNo",
+                  value: v,
+                  filter: !!v ? `codePreAuthorization_Icontains: "${v}"` : null,
+                },
+              ])
+            }
+          />
+        </Grid>
         <Grid item xs={3} className={classes.item}>
           <TextInput
             module="claim"

--- a/src/components/ClaimMasterPanel.js
+++ b/src/components/ClaimMasterPanel.js
@@ -148,7 +148,7 @@ class ClaimMasterPanel extends FormPanel {
     edited.claimed = _.round(totalClaimed, 2);
     edited.approved = _.round(totalApproved, 2);
     let ro = readOnly || !!forReview || !!forFeedback;
-    let isPreAuthorization = edited.isPreAuthorization;
+    let isPreAuthorization = !!edited.isPreAuthorization;
     return (
       <Grid container>
         <ControlledField

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -178,6 +178,7 @@ class ClaimSearcher extends Component {
   headers = () => {
     var result = [
       "claimSummaries.code",
+      "claimSummaries.preAuthcode",
       "claimSummaries.healthFacility",
       "claimSummaries.insuree",
       "claimSummaries.prescriber",
@@ -241,6 +242,7 @@ class ClaimSearcher extends Component {
   itemFormatters = () => {
     var result = [
       (c) => c.code,
+      (c) => c?.codePreAuthorization,
       (c) => (
         <PublishedComponent
           readOnly={true}

--- a/src/pages/HealthFacilitiesPage.js
+++ b/src/pages/HealthFacilitiesPage.js
@@ -57,7 +57,7 @@ class HealthFacilitiesPage extends Component {
   canSubmitSelected = (selection) =>
     !!selection &&
     selection.length &&
-    selection.filter((s) => s.status === 2 && (!!this.canSubmitClaimWithZero || s.claimed > 0)).length ===
+    selection.filter((s) => !!s.code && s.status === 2 && (!!this.canSubmitClaimWithZero || s.claimed > 0)).length ===
       selection.length;
 
   canSubmitAll = (selection) => !selection || selection.length == 0;


### PR DESCRIPTION
Mainenant on peut filtrer les prestations par le code de preAUthrorisation si jamais elle est issue d'une OP3 pour pouvoir faciliter la transition
Maintenat seuls les prestations avec un codepeuvent etre soumis pour revue fix pour la transistion Op3 et PEC
