### PR TITLE
remove main diagnosis field in claim form

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ None
 - `claimForm.claimTypeReferSymbol`, used for checking referHF option, indicate which letter represents referal. Default R.
 - `claimForm.autoGenerateClaimCode`, boolean to enable autogenerating claim code by the backend. Default false.
 - `claimForm.numberOfAdditionalDiagnosis`, integer to enable required number of additional diagnoses. Default 4, up to 4 supported.
+- `claimForm.useMainDiagnosis`, boolean to enable use of main diagnosis. Default false.
 - `claimForm.isExplanationMandatoryForIPD`, boolean to enable check for required explanation if visit type is IPD. Default false.
 - `claimForm.isCareTypeMandatory`, boolean to set CareType (in/out patient) field to mandatory. It removes "any" option. Default false.
 - `reviews.defaultFilters`, default filters for claim review searcher. The code snippet below sets the default values for 'Claim Status' and 'Claimed Less Than' in the Review page. Specifically, it sets 'Claim Status' to the value of 4 (which means 'Checked') and 'Claimed Less Than' to a value of 1,000,000.

--- a/src/actions.js
+++ b/src/actions.js
@@ -259,7 +259,7 @@ export function formatClaimGQL(modulesManager, claim, shouldAutogenerate) {
     adminId: ${decodeId(claim.admin.id)}
     dateFrom: "${claim.dateFrom}"
     ${claim.dateTo ? `dateTo: "${claim.dateTo}"` : ""}
-    icdId: ${decodeId(claim.icd.id)}
+    ${!!claim.icd ? `icdId: ${decodeId(claim.icd.id)}` : ""}
     ${!!claim.icd1 ? `icd1Id: ${decodeId(claim.icd1.id)}` : ""}
     ${!!claim.icd2 ? `icd2Id: ${decodeId(claim.icd2.id)}` : ""}
     ${!!claim.icd3 ? `icd3Id: ${decodeId(claim.icd3.id)}` : ""}

--- a/src/components/ClaimForm.js
+++ b/src/components/ClaimForm.js
@@ -101,6 +101,7 @@ class ClaimForm extends Component {
       "canSaveClaimWithoutServiceNorItem",
       true,
     );
+    this.useMainDiagnosis = props.modulesManager.getConf("fe-claim", "claimForm.useMainDiagnosis", false);
     this.claimAttachments = props.modulesManager.getConf("fe-claim", "claimAttachments", true);
     this.claimTypeReferSymbol = props.modulesManager.getConf("fe-claim", "claimForm.claimTypeReferSymbol", "R");
     this.autoGenerateClaimCode = props.modulesManager.getConf(
@@ -292,7 +293,7 @@ class ClaimForm extends Component {
     }
     if (this.state.claim.dateClaimed < this.state.claim.dateFrom) return false;
     if (!!this.state.claim.dateTo && this.state.claim.dateFrom > this.state.claim.dateTo) return false;
-    if (!this.state.claim.icd) return false;
+    if (!this.state.claim.icd && this.useMainDiagnosis) return false;
     if (
       (this.state.claim.visitType == REFERRAL || this.state.claim.patientCondition == REFERRAL) &&
       (!this.state.claim.referralCode || this.state.claim.referralCode == null || this.state.claim.referralCode == undefined)

--- a/src/components/ClaimMasterPanel.js
+++ b/src/components/ClaimMasterPanel.js
@@ -67,6 +67,7 @@ class ClaimMasterPanel extends FormPanel {
       "claimForm.numberOfAdditionalDiagnosis",
       DEFAULT_ADDITIONAL_DIAGNOSIS_NUMBER,
     );
+    this.useMainDiagnosis = props.modulesManager.getConf("fe-claim", "claimForm.useMainDiagnosis", false);
     this.isExplanationMandatoryForIPD = props.modulesManager.getConf(
       "fe-claim",
       "claimForm.isExplanationMandatoryForIPD",
@@ -275,7 +276,7 @@ class ClaimMasterPanel extends FormPanel {
             </Grid>
           }
         />
-        {!forFeedback && (
+        {(!forFeedback && this.useMainDiagnosis) && (
           <ControlledField
             module="claim"
             id="Claim.mainDiagnosis"


### PR DESCRIPTION
we used a config "useMainDiagnosis" set to false by default to hide the mainDiagnosis field in claim form